### PR TITLE
Removed call to `TryCreateDirectory` from `GetDefaultDataDir` in `src/util.cpp`.

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -472,7 +472,6 @@ boost::filesystem::path GetDefaultDataDir()
 #ifdef MAC_OSX
     // Mac
     pathRet /= "Library/Application Support";
-    TryCreateDirectory(pathRet);
     return pathRet / "Bitcoin";
 #else
     // Unix


### PR DESCRIPTION
See https://github.com/bitcoin/bitcoin/issues/7845#issuecomment-207684728.
